### PR TITLE
feat: add tmux/tmux.conf to git tracking

### DIFF
--- a/dot_config/.gitignore
+++ b/dot_config/.gitignore
@@ -16,6 +16,7 @@
 !zellij/
 !todotui/
 !todotui/*
+!tmux/
 !tmux/*
 
 # And not this file

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -1,0 +1,66 @@
+# Vimのキーバインドでペインを移動する
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Vimのキーバインドでペインをリサイズする
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+setw -g mode-keys vi
+set -g mouse on
+
+# 日本語入力の重複問題を解決
+set -g escape-time 0
+set -g repeat-time 0
+set -s escape-time 0
+
+# macOSでの日本語入力問題対策
+set -g default-terminal "screen-256color"
+set -ag terminal-overrides ',xterm-256color:Tc'
+
+# 設定ファイルをリロードするキーバインド
+bind r source-file ~/.config/tmux/tmux.conf \; display-message "Config reloaded!"   
+
+bind '"' split-window -c "#{pane_current_path}"
+bind % split-window -h -c "#{pane_current_path}"
+
+set -g @plugin 'catppuccin/tmux#v2.1.3' # See https://github.com/catppuccin/tmux/tags for additional tags
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+# Catppuccin theme configuration
+set -g @catppuccin_window_current_fill "number"
+set -g @catppuccin_window_default_fill "number"
+
+set -g @catppuccin_window_left_separator ""
+set -g @catppuccin_window_right_separator " "
+set -g @catppuccin_window_middle_separator " █"
+set -g @catppuccin_window_number_position "right"
+
+set -g @catppuccin_window_default_text "#W"
+set -g @catppuccin_window_current_text "#W"
+
+set -g @catppuccin_status_modules_right "directory session"
+set -g @catppuccin_status_left_separator  " "
+set -g @catppuccin_status_right_separator ""
+set -g @catppuccin_status_fill "icon"
+set -g @catppuccin_status_connect_separator "no"
+
+set -g @catppuccin_directory_text "#{pane_current_path}"
+
+# Other examples:
+# set -g @plugin 'github_username/plugin_name'
+# set -g @plugin 'github_username/plugin_name#branch'
+# set -g @plugin 'git@github.com:user/plugin'
+# set -g @plugin 'git@bitbucket.com:user/plugin'
+
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+run '~/.tmux/plugins/tpm/tpm'
+
+
+
+


### PR DESCRIPTION
## Summary
- Add `\!tmux/` to .gitignore to properly unignore tmux directory
- Previously only `\!tmux/*` was present, which didn't unignore the directory itself
- This allows tmux.conf to be properly tracked by git

## Test plan
- [x] Verified that tmux.conf is now tracked by git status
- [x] Confirmed git check-ignore no longer ignores the file
- [x] Tested that all tmux directory contents are properly included

## Changes
- Modified `dot_config/.gitignore` to add `\!tmux/` before `\!tmux/*`
- Added `dot_config/tmux/tmux.conf` to git tracking