### PR TITLE
feat: add tmux-ccusage plugin for cost tracking

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -43,11 +43,14 @@ set -g @catppuccin_date_time_text '%d.%m. %H:%M'
 set -g @catppuccin_status_module_text_bg '#{E:@thm_mantle}'
 
 set -g @plugin 'catppuccin/tmux#v2.1.3' # See https://github.com/catppuccin/tmux/tags for additional tags
+set -g @plugin 'yanskun/tmux-ccusage'
 
 set -gF  status-right "#{@catppuccin_status_directory}"
 # Status modules config
 set -g @catppuccin_date_time_text "%m-%d %H:%M"
 set -agF status-right "#{E:@catppuccin_status_date_time}"
+# Add ccusage cost display to status bar
+set -agF status-right " | Month: #{ccusage_month_cost} Today: #{ccusage_today_cost}"
 
 # set left and right status bar
 set -g status-interval 5


### PR DESCRIPTION
## Summary
- `yanskun/tmux-ccusage` プラグインを追加
- tmuxステータスバーの右下に今日のコストと月間コストを表示
- 表示形式: "Month: $X.XX Today: $Y.YY"

## 変更内容
- `dot_config/tmux/tmux.conf` に tmux-ccusage プラグインを追加
- status-right 設定に ccusage_today_cost と ccusage_month_cost の表示を追加

## Test plan
- [ ] tmux設定ファイルの構文チェック
- [ ] プラグインのインストール (tmux内で `prefix + I`)
- [ ] ccusageコマンドの動作確認
- [ ] ステータスバーでのコスト表示確認