### PR TITLE
chore: hunk を宣言に追加 / CLAUDE.local.md を gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # マシンローカル設定（work の identity・社内 URL 等）
 local/
+CLAUDE.local.md
 
 # Nix
 result

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -20,7 +20,7 @@ _: {
     # - awscli は mise（config/mise/config.toml）で管理
     # - node: ccusage（brew formula）の依存 + グローバル npm 用
     # - coreutils / grep: brew は g-prefix で共存、nixpkgs は無印で BSD コマンドを隠すため
-    # - herdr / rtk / worktrunk / chrome-cli: nixpkgs 未収載（tap・独自 formula）
+    # - herdr / rtk / worktrunk / chrome-cli / hunk: nixpkgs 未収載（tap・独自 formula）
     # - glib / pango / vips / ffmpeg / graphviz: ライブラリ・重量級のため当面 brew
     brews = [
       "bash-completion@2"
@@ -36,6 +36,7 @@ _: {
       "graphviz"
       "grep"
       "herdr"
+      "hunk"
       "mise"
       "pipx"
       "rtk"


### PR DESCRIPTION
## 概要

2 点の設定変更。

### 1. hunk を Homebrew 宣言に追加
hunk（review-first terminal diff viewer / https://hunk.dev/）を brew で導入したため、宣言的管理に追加する。`onActivation.cleanup = "uninstall"` により宣言にない formula は `make switch` 時に削除されるため、宣言へ追加して消えないようにする。nixpkgs 未収載のため brew 管理。

### 2. CLAUDE.local.md を gitignore
git 管理外のローカル向け CLAUDE.md（作業時のアカウント指定等、マシン固有の指示）を置けるように `.gitignore` へ追加する。

## 変更

- `darwin/homebrew.nix`: `brews` に `hunk` を追加 + 理由コメント追記
- `.gitignore`: `CLAUDE.local.md` を追跡対象外に追加

## 検証

- `make ci-check` パス（pre-push でも通過）