### PR TITLE
fix(zsh): zinit atpull をサブシェル化して cwd 汚染を防ぐ

### DIFF
--- a/config/zsh/zshrc
+++ b/config/zsh/zshrc
@@ -54,7 +54,7 @@ autoload -Uz _zinit
 zinit wait lucid light-mode for \
     @'zsh-users/zsh-autosuggestions' \
     @'paulirish/git-open' \
-    blockf atpull'zinit creinstall -q .' atload'zicompinit; zicdreplay' \
+    blockf atpull'(zinit creinstall -q .)' atload'zicompinit; zicdreplay' \
     @'zsh-users/zsh-completions' \
     @'zsh-users/zsh-syntax-highlighting'
 


### PR DESCRIPTION
## 概要

`lg`（lazygit）等を実行した後、稀にカレントディレクトリが `zinit/plugins/zsh-users---zsh-completions` に移動してしまう問題を修正する。

## 原因

`config/zsh/zshrc` の zinit プラグイン読み込みで、`zsh-completions` に付いている `atpull'zinit creinstall -q .'` フックが原因。

プラグインの自動更新（pull）が走ったタイミングで `creinstall` が実行され、その過程でカレントディレクトリが plugin ディレクトリへ `cd` したまま戻らず、プロンプトへ制御が返っていた。

- 「毎回ではなく、たまに」発生する → 更新チェックが走ったときだけ atpull が発火するため
- 移動先が `zinit/plugins/zsh-users---zsh-completions` → まさに atpull の対象プラグイン
- 直前コマンドに `took 7s` 等の時間がかかる → 再インストール処理の時間

## 修正

atpull の中身を `( )` でサブシェル化し、`creinstall` が `cd` してもカレントシェルの cwd に影響しないようにした。

\`\`\`diff
-    blockf atpull'zinit creinstall -q .' atload'zicompinit; zicdreplay' \
+    blockf atpull'(zinit creinstall -q .)' atload'zicompinit; zicdreplay' \
\`\`\`

## 検証

- `make ci-check`：✅ 全通過（nix flake check / build dry-run / gitleaks）