### PR TITLE
fix(ci): lint 対象を find ベースの全 .sh / .nix 走査に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules/
 package-lock.json
 package.json
 
+# Python
+__pycache__/
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/flake.nix
+++ b/flake.nix
@@ -70,9 +70,11 @@
       checks = forAllSystems (pkgs: {
         lint = pkgs.runCommand "dotfiles-lint" { nativeBuildInputs = lintTools pkgs; } ''
           cd ${self}
-          shellcheck scripts/*.sh
+          # git 追跡ファイルのみ flake source にコピーされるため、
+          # find による全走査は git ls-files 相当（runCommand 内に git は無い）。
+          find . -type f -name '*.sh' -exec shellcheck {} +
           stylua --check config/nvim/
-          nixfmt --check flake.nix darwin/*.nix home/*.nix
+          find . -type f -name '*.nix' -exec nixfmt --check {} +
           statix check .
           deadnix --fail .
           touch $out


### PR DESCRIPTION
## 概要

`checks.lint`（`dotfiles-lint`）のカバレッジ漏れを修正します。

## 背景・課題

- `shellcheck scripts/*.sh` のみのため、git 追跡中の以下 3 ファイルが lint 対象外だった:
  - `config/claude/hooks/herdr-agent-state.sh`
  - `config/codex/herdr-agent-state.sh`
  - `config/codex/scripts/notify.sh`
- `nixfmt --check flake.nix darwin/*.nix home/*.nix` が列挙式で、新ディレクトリの `.nix` が漏れるリスクがあった。

## 変更内容

- shellcheck / nixfmt を `find` ベースの全 `.sh` / `.nix` 走査に変更。
  - flake source には git 追跡ファイルのみコピーされるため、`cd ${self}` 後の `find` は `git ls-files` 相当で安全（runCommand 内に git は無いため find を使用）。
- `.gitignore` に `__pycache__/` を追加（Python セクション）。

## 検証

`make ci-check` パス（nix flake check + gitleaks、pre-push でも通過確認済み）。3 つの `.sh` ファイルは追加修正なしで shellcheck を通過。