### PR TITLE
feat(ci): flake.lock の週次自動更新 workflow を追加

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,32 @@
+name: Update flake.lock
+
+on:
+  # 毎週月曜の早朝（JST 09:00 = UTC 00:00）に実行する
+  schedule:
+    - cron: "0 0 * * 1"
+  # 手動実行も許可する
+  workflow_dispatch:
+
+# 最小限の権限のみ付与する
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    name: Update flake.lock
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v28
+        with:
+          pr-title: "chore(deps): flake.lock を更新"
+          pr-labels: dependencies
+          branch: chore/update-flake-lock
+          commit-msg: "chore(deps): flake.lock を更新"


### PR DESCRIPTION
## 概要

`flake.lock` を週次で自動更新する GitHub Actions workflow を追加する。

- 毎週月曜早朝（JST 09:00 / UTC 00:00）の cron + `workflow_dispatch` による手動実行
- `DeterminateSystems/nix-installer-action` で Nix をインストールし、`DeterminateSystems/update-flake-lock` で `flake.lock` 更新 PR を自動作成
- PR タイトル / ブランチ名は既存の流儀に合わせる（`chore(deps): flake.lock を更新` / `chore/update-flake-lock`）
- `permissions` は最小限（`contents: write`, `pull-requests: write`）を明示

## 既知の制約

- **CI がトリガーされない**: デフォルトの `GITHUB_TOKEN` で作成された PR には、他の workflow（`ci.yml` 等）が原則トリガーされない GitHub の仕様がある。自動更新 PR でも CI を回したい場合は、`update-flake-lock` の `token` に PAT または GitHub App トークンを渡す構成に置き換える選択肢がある（本 PR ではデフォルトの `GITHUB_TOKEN` のまま）。
- **リポジトリ設定の前提**: Actions が PR を作成するには「Allow GitHub Actions to create and approve pull requests」が有効である必要がある。
  - `gh api repos/yuucu/dotfiles/actions/permissions/workflow` の結果:
    ```json
    {"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}
    ```
  - `can_approve_pull_request_reviews: true` のため、現時点で有効。本 PR では設定変更は行わない。

## 検証

- `nix run nixpkgs#actionlint` で新 workflow を検証済み（エラーなし）
- `make ci-check` パス