### PR TITLE
feat(ci): YAML / TOML / GitHub Actions の lint レイヤーを追加

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,15 @@
+# yamllint 設定（既存ファイルが通る最小限の緩和）
+extends: default
+
+rules:
+  # 行長はエディタ側で管理するため無効化
+  line-length: disable
+  # ドキュメント先頭の `---` を必須にしない
+  document-start: disable
+  # GitHub Actions の `on:` を truthy 扱いしない
+  truthy:
+    check-keys: false
+  # コメントのフォーマット差異は許容
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable

--- a/flake.nix
+++ b/flake.nix
@@ -31,11 +31,14 @@
         ] (system: f nixpkgs.legacyPackages.${system});
       lintTools =
         pkgs: with pkgs; [
+          actionlint
           deadnix
           nixfmt
           shellcheck
           statix
           stylua
+          taplo
+          yamllint
         ];
     in
     {
@@ -75,6 +78,12 @@
           nixfmt --check flake.nix darwin/*.nix home/*.nix
           statix check .
           deadnix --fail .
+          # GitHub Actions ワークフロー（sandbox 内は git repo でないためファイルを明示）
+          actionlint .github/workflows/*.yml
+          # YAML lint（追跡中の .yml を find で走査。設定は .yamllint.yml）
+          find . -type f -name '*.yml' -print0 | xargs -0 yamllint -c .yamllint.yml
+          # TOML lint（構文チェックのみ。sandbox 内でネットワークに出ないようスキーマ検証はオフ）
+          find . -type f -name '*.toml' -print0 | xargs -0 taplo lint --no-schema
           touch $out
         '';
       });


### PR DESCRIPTION
## 概要

CI（`checks.lint`）と devShell に YAML / TOML / GitHub Actions 向けの lint を追加します。既存の追跡ファイルは修正なしで通ります。

## 変更内容

- `lintTools` に `actionlint` / `yamllint` / `taplo` を追加（devShell と `checks.lint` の両方で共有）
- `checks.lint` の runCommand に以下を追加:
  - `actionlint` で `.github/workflows/*.yml` を検証（nix sandbox は git repo でないためファイルを明示指定）
  - `yamllint` で追跡中の `.yml` を find ベースで走査
  - `taplo lint --no-schema` で `.toml` の構文をチェック（sandbox 内でネットワークにスキーマ取得へ出ないよう検証はオフ）
- `.yamllint.yml` を新規追加。`extends: default` をベースに `line-length` / `document-start` を無効化、GitHub Actions の `on:` を truthy 扱いしないよう緩和

## 検証

`make ci-check` が全て pass することを確認済み。