### PR TITLE
feat(ci): selene による Lua lint を追加

### DIFF
--- a/config/nvim/lua/utils/notes.lua
+++ b/config/nvim/lua/utils/notes.lua
@@ -2,15 +2,6 @@
 local M = {}
 local constants = require('core.constants')
 
--- Helper function to get git repository root
-local function get_git_root(path)
-  local result = vim.fn.system('git -C ' .. vim.fn.shellescape(path) .. ' rev-parse --show-toplevel 2>/dev/null')
-  if vim.v.shell_error ~= 0 then
-    return nil
-  end
-  return result:gsub('\n', '')
-end
-
 -- Function to create a new note with date prefix
 function M.create_new_note()
   -- Get current date in YYYYMMDD format

--- a/config/nvim/selene.toml
+++ b/config/nvim/selene.toml
@@ -1,0 +1,9 @@
+# selene: Neovim 設定（Lua）向けの lint 設定
+# std に lua51 と自前の vim 定義（vim.yml）を合成する。
+std = "lua51+vim"
+
+[rules]
+# lazy.nvim のプラグイン仕様は配列とキーが混在するテーブルが標準スタイルのため許可する。
+mixed_table = "allow"
+# alpha ダッシュボードから呼ぶ関数を _G に公開する箇所があるため許可する。
+global_usage = "allow"

--- a/config/nvim/vim.yml
+++ b/config/nvim/vim.yml
@@ -1,0 +1,7 @@
+# selene 用の Neovim(vim) 標準ライブラリ定義。
+# vim.* の API は膨大なため、誤検知を避けて any として許可する。
+# これにより undefined_variable(`vim`) を防ぎつつ実バグ検出に集中できる。
+base: lua51
+globals:
+  vim:
+    any: true

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
           actionlint
           deadnix
           nixfmt
+          selene
           shellcheck
           statix
           stylua
@@ -77,6 +78,8 @@
           # find による全走査は git ls-files 相当（runCommand 内に git は無い）。
           find . -type f -name '*.sh' -exec shellcheck {} +
           stylua --check config/nvim/
+          # selene は CWD の selene.toml / vim.yml を参照するため config/nvim/ 内で実行する
+          ( cd config/nvim && selene . )
           find . -type f -name '*.nix' -exec nixfmt --check {} +
           statix check .
           deadnix --fail .


### PR DESCRIPTION
## 概要

Neovim 設定（`config/nvim/` 配下の Lua 59 ファイル）に対して selene で lint を実行するようにしました。

これまで stylua（フォーマットチェックのみ）しかなく、未定義変数などの実バグを検出できませんでした。selene を追加することで CI でこれらを検出できます。

## 変更内容

- `flake.nix` の `lintTools` に `selene` を追加
- `checks.lint`（`nix flake check` の実体）に `config/nvim/` への lint 実行を追加
  - selene は CWD の設定ファイルを参照するため、`config/nvim/` 内で実行する
- `config/nvim/selene.toml` / `config/nvim/vim.yml` を追加
  - `std = "lua51+vim"`。`vim.*` API は膨大なため `any` として許可し、実バグ検出に集中
  - lazy.nvim のプラグイン仕様由来の `mixed_table` と、意図的な `_G` 公開の `global_usage` は許可
- デッドコード（未使用の `get_git_root`）を削除

## linter 選定理由

selene を第一候補どおり採用。vim std を `any` 許可した最小構成で、既存 59 ファイルが 0 errors / 0 warnings で通ることを確認しました。

## 検証

- selene: `config/nvim/` に対し **0 errors / 0 warnings**
- `make ci-check`: **All checks passed**（selene が `nix flake check` の lint に統合済み）