### PR TITLE
ci: update-flake-lock.yml の Actions を SHA 固定

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -18,13 +18,13 @@ jobs:
     name: Update flake.lock
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v28
+        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
         with:
           pr-title: "chore(deps): flake.lock を更新"
           pr-labels: dependencies


### PR DESCRIPTION
## 概要

`.github/workflows/update-flake-lock.yml` の `uses:` を mutable なタグ参照から「SHA + バージョンコメント」形式に固定する。ci.yml と同じピン形式に揃える。

## 変更内容

- `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `DeterminateSystems/nix-installer-action@v22` → `@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22`
- `DeterminateSystems/update-flake-lock@v28` → `@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28`

前者 2 つは ci.yml の既存ピンと同一 SHA。

## 背景

mutable なタグ参照はタグの差し替え攻撃に弱い。とくにこの workflow は `contents: write` 権限を持つため、乗っ取られた場合の影響が大きい。SHA 固定によりサプライチェーンリスクを抑える。