### PR TITLE
ci: Dependabot で GitHub Actions の SHA 固定を週次更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # SHA 固定した Actions の更新 PR を自動作成する
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` を新規追加し、GitHub Actions の依存を週次で更新する PR を Dependabot に自動作成させる。

## 変更内容

```yaml
version: 2
updates:
  # SHA 固定した Actions の更新 PR を自動作成する
  - package-ecosystem: github-actions
    directory: /
    schedule:
      interval: weekly
```

## 背景

Actions を SHA 固定するとバージョンが自動追従しなくなるため、更新の取りこぼしが起きやすい。Dependabot に週次で更新 PR を作らせることで、SHA 固定の安全性を保ちながら更新の追従を自動化する。