### PR TITLE
fix(ci): update-flake-lock に PAT を渡して自動 PR で CI が走るようにする

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
         with:
+          # デフォルトの GITHUB_TOKEN だと作成した PR に CI がトリガーされないため、
+          # fine-grained PAT（yuucu/dotfiles 限定、contents / pull-requests: write）を使う
+          token: ${{ secrets.UPDATE_FLAKE_LOCK_TOKEN }}
           pr-title: "chore(deps): flake.lock を更新"
           pr-labels: dependencies
           branch: chore/update-flake-lock


### PR DESCRIPTION
## 概要
update-flake-lock が GITHUB_TOKEN で PR を作ると、GitHub の仕様（workflow 連鎖防止）により CI がトリガーされない。fine-grained PAT（repo secret \`UPDATE_FLAKE_LOCK_TOKEN\`、yuucu/dotfiles 限定・contents / pull-requests: write のみ）を \`token\` に渡すことで、自動作成された PR に最初から CI が走るようにする。

## 動作確認
- \`make ci-check\`（actionlint 含む）: pass
- マージ後に \`workflow_dispatch\` で再実行し、自動 PR に CI が走ることを確認予定