### PR TITLE
fix(mise): awscli を latest からバージョン固定に変更

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,2 +1,4 @@
+# サプライチェーン対策としてバージョンを固定する（"latest" は使わない）。
+# 更新手順: mise latest awscli で新バージョンを確認して書き換え、mise install を実行
 [tools]
-awscli = "latest"
+awscli = "2.35.15"


### PR DESCRIPTION
## 概要

サプライチェーン対策の中優先度対応。`awscli = "latest"` は取得タイミング依存で再現性がなく、リリース乗っ取り時に無防備なため、現在使用中の 2.35.15 に固定する（動作変更なし）。更新手順はコメントに記載。

## 検証

- `make ci-check` 通過（taplo lint 含む）