### PR TITLE
feat(scripts): mac 導入をワンライナー化する bootstrap.sh を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,10 @@ jobs:
 
       # checks.lint（shellcheck / stylua / nixfmt / statix / deadnix）も
       # ここでビルドされる。ツールのバージョンは flake.lock で固定
-      # pure eval では flake.nix の username が既定値へフォールバックするため
-      # attribute 名は <既定ユーザー>-mac になる
+      # darwinConfigurations の attribute 名は username に追従して動的なため、
+      # 名前を決め打ちせず flake 自身に問い合わせてからビルドする
       - name: Flake check
         run: |
           nix flake check
-          nix build .#darwinConfigurations.s09104-mac.system --dry-run
+          target=$(nix eval .#darwinConfigurations --apply 'cfgs: builtins.head (builtins.attrNames cfgs)' --raw)
+          nix build ".#darwinConfigurations.${target}.system" --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
 
       # checks.lint（shellcheck / stylua / nixfmt / statix / deadnix）も
       # ここでビルドされる。ツールのバージョンは flake.lock で固定
+      # pure eval では flake.nix の username が既定値へフォールバックするため
+      # attribute 名は <既定ユーザー>-mac になる
       - name: Flake check
         run: |
           nix flake check
-          nix build .#darwinConfigurations.yuucu-mac.system --dry-run
+          nix build .#darwinConfigurations.s09104-mac.system --dry-run

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ gc: ## 🗑  30 日より古い世代を削除して Nix store を GC
 
 ci-check: ## 🔍 CI と同じチェックをローカルで実行
 	@chmod +x scripts/ci-check.sh
-	@FLAKE_TARGET=$(FLAKE_TARGET) scripts/ci-check.sh
+	@scripts/ci-check.sh
 
 hook-install: ## 🪝 lefthook をインストール
 	@lefthook install

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 
 .PHONY: help switch check update fmt gc ci-check hook-install status
 
-FLAKE_TARGET := yuucu-mac
+# username は実ログインユーザーに追従（flake.nix が DOTFILES_USER を参照）。
+# sudo 実行下でも元のユーザーを拾うため SUDO_USER を優先する。
+DOTFILES_USER := $(shell echo $${SUDO_USER:-$$(whoami)})
+FLAKE_TARGET := $(DOTFILES_USER)-mac
+export DOTFILES_USER
 
 # Colors for output
 GREEN := \033[32m
@@ -17,11 +21,11 @@ help: ## このヘルプメッセージを表示
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-20s$(RESET) %s\n", $$1, $$2}'
 
 switch: ## 🔄 flake の変更をシステムに適用（darwin-rebuild switch）
-	@sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#$(FLAKE_TARGET)
+	@sudo DOTFILES_USER=$(DOTFILES_USER) /run/current-system/sw/bin/darwin-rebuild switch --impure --flake .#$(FLAKE_TARGET)
 
 check: ## 🔍 flake の評価チェック（適用はしない）
 	@nix flake check
-	@nix build .#darwinConfigurations.$(FLAKE_TARGET).system --dry-run
+	@nix build .#darwinConfigurations.$(FLAKE_TARGET).system --dry-run --impure
 
 update: ## 📦 flake inputs・Neovim プラグイン・mise ツールの更新
 	@echo "$(BLUE)📦 flake inputs を更新中...$(RESET)"

--- a/README.md
+++ b/README.md
@@ -76,14 +76,16 @@ mkdir -p ~/ghq/github.com/yuucu
 git clone https://github.com/yuucu/dotfiles ~/ghq/github.com/yuucu/dotfiles
 cd ~/ghq/github.com/yuucu/dotfiles
 
-# 4. flake.nix の username / darwinConfigurations 名をそのマシンに合わせて確認
+# 4. 適用（初回。dotfiles の symlink と brew パッケージ一式が入る）
+#    username は実ログインユーザーに追従するため（flake.nix が DOTFILES_USER を参照）、
+#    getEnv を使う都合で --impure を付ける。config 名も <ユーザー名>-mac になる。
+sudo DOTFILES_USER="$(whoami)" nix run nix-darwin/master -- switch --impure --flake ".#$(whoami)-mac"
 
-# 5. 適用（初回。dotfiles の symlink と brew パッケージ一式が入る）
-sudo nix run nix-darwin/master -- switch --flake .#yuucu-mac
-
-# 6. 以降の適用
+# 5. 以降の適用
 make switch
 ```
+
+> flake.nix の `username` は `DOTFILES_USER`（未設定なら実ログインユーザー）に追従します。以前必要だった「flake.nix の username を手で書き換える」手順は不要です。
 
 ### 適用後の手作業（最小限）
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ flowchart TB
 
 ## セットアップ（新しい Mac）
 
+### ワンライナー
+
+Xcode CLT / Homebrew / Nix / clone / 初回適用までを bootstrap スクリプトが冪等に実行します。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yuucu/dotfiles/main/scripts/bootstrap.sh | bash
+```
+
+途中 Xcode CLT のインストールと `sudo` のパスワード入力で対話が入ります。何度実行しても既存分はスキップされます（冪等）。処理内容は [scripts/bootstrap.sh](scripts/bootstrap.sh) を参照。
+
+### 手動セットアップ（中身を把握したいとき）
+
 ```bash
 # 1. Xcode CLT と Homebrew（brew 管理のパッケージ用）
 xcode-select --install

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,12 @@
       home-manager,
     }:
     let
-      username = "s09104";
+      # 実ログインユーザーに追従させる（新しい Mac でユーザー名が異なっても動く）。
+      # getEnv は impure なため、適用は `--impure` 付きで行う（make switch / bootstrap.sh が付与）。
+      # pure eval（`nix flake check`）では getEnv が "" を返すため、その場合は既定値へフォールバックする。
+      envUser = builtins.getEnv "DOTFILES_USER";
+      username = if envUser != "" then envUser else "s09104";
+      hostConfig = "${username}-mac";
       # x86_64-linux は Phase 4 の Linux（home-manager 単体）対応を見据えた先行出力
       forAllSystems =
         f:
@@ -43,7 +48,7 @@
         ];
     in
     {
-      darwinConfigurations."yuucu-mac" = nix-darwin.lib.darwinSystem {
+      darwinConfigurations.${hostConfig} = nix-darwin.lib.darwinSystem {
         specialArgs = { inherit username; };
         modules = [
           ./darwin

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# dotfiles bootstrap (macOS)
+#
+# 新しい Mac で以下を非対話・冪等に実行する:
+#   1. Xcode Command Line Tools
+#   2. Homebrew
+#   3. Nix (Determinate Systems installer)
+#   4. dotfiles の clone
+#   5. nix-darwin の初回適用（darwin-rebuild switch）
+#
+# 使い方（ワンライナー）:
+#   curl -fsSL https://raw.githubusercontent.com/yuucu/dotfiles/main/scripts/bootstrap.sh | bash
+#
+# 適用後の手作業（このスクリプトでは扱わない・最後に案内する）:
+#   - local/ の作成（work の git identity・社内 URL 等。git 管理外）
+#   - シェルの開き直し（zinit・プラグインは初回起動時に自動インストール）
+#   - mise install / gh auth login などツール個別のログイン
+# ============================================================================
+
+GREEN='\033[32m'
+BLUE='\033[34m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+REPO_URL="https://github.com/yuucu/dotfiles"
+REPO_DIR="${HOME}/ghq/github.com/yuucu/dotfiles"
+FLAKE_TARGET="yuucu-mac"
+
+log() { echo -e "${BLUE}==> $*${RESET}"; }
+ok() { echo -e "  ${GREEN}✅ $*${RESET}"; }
+warn() { echo -e "  ${YELLOW}⚠️  $*${RESET}"; }
+err() { echo -e "  ${RED}❌ $*${RESET}"; }
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    err "このスクリプトは macOS 専用です（uname: $(uname -s)）"
+    exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# 1. Xcode Command Line Tools
+# ----------------------------------------------------------------------------
+log "1/5 Xcode Command Line Tools"
+if xcode-select -p >/dev/null 2>&1; then
+    ok "既にインストール済み"
+else
+    warn "インストールを開始します（GUI ダイアログが開きます）"
+    xcode-select --install || true
+    echo -e "  ${YELLOW}ダイアログでインストールを完了させてから Enter を押してください${RESET}"
+    read -r _
+    xcode-select -p >/dev/null 2>&1 || {
+        err "Xcode CLT が見つかりません。インストール完了後に再実行してください"
+        exit 1
+    }
+    ok "インストール完了"
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Homebrew
+# ----------------------------------------------------------------------------
+log "2/5 Homebrew"
+if command -v brew >/dev/null 2>&1; then
+    ok "既にインストール済み（$(brew --version | head -1)）"
+else
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    # 現在のシェルに brew を通す（Apple Silicon / Intel 両対応）
+    if [ -x /opt/homebrew/bin/brew ]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -x /usr/local/bin/brew ]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+    ok "インストール完了"
+fi
+
+# ----------------------------------------------------------------------------
+# 3. Nix (Determinate Systems installer)
+# ----------------------------------------------------------------------------
+log "3/5 Nix"
+if command -v nix >/dev/null 2>&1; then
+    ok "既にインストール済み（$(nix --version)）"
+else
+    curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm
+    # 現在のシェルに nix を通す
+    if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+        # shellcheck disable=SC1091
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    fi
+    ok "インストール完了"
+fi
+
+# ----------------------------------------------------------------------------
+# 4. dotfiles の clone
+# ----------------------------------------------------------------------------
+log "4/5 dotfiles clone"
+if [ -d "${REPO_DIR}/.git" ]; then
+    ok "既に clone 済み（${REPO_DIR}）"
+else
+    mkdir -p "$(dirname "${REPO_DIR}")"
+    git clone "${REPO_URL}" "${REPO_DIR}"
+    ok "clone 完了（${REPO_DIR}）"
+fi
+
+# ----------------------------------------------------------------------------
+# 5. nix-darwin の初回適用
+# ----------------------------------------------------------------------------
+log "5/5 nix-darwin 初回適用（.#${FLAKE_TARGET}）"
+cd "${REPO_DIR}"
+if command -v darwin-rebuild >/dev/null 2>&1; then
+    ok "darwin-rebuild が既にある → make switch で適用"
+    sudo /run/current-system/sw/bin/darwin-rebuild switch --flake ".#${FLAKE_TARGET}"
+else
+    warn "初回のため nix run で nix-darwin を適用します（sudo でパスワードを求められます）"
+    sudo nix run nix-darwin/master -- switch --flake ".#${FLAKE_TARGET}"
+fi
+ok "適用完了"
+
+# ----------------------------------------------------------------------------
+# 完了 & 手作業の案内
+# ----------------------------------------------------------------------------
+echo ""
+echo -e "${GREEN}🎉 bootstrap 完了${RESET}"
+echo ""
+echo -e "${YELLOW}残りの手作業（最小限）:${RESET}"
+echo "  1. local/ の作成（git 管理外。ないと ~/.gitconfig 等の symlink が空振りする）"
+echo "     - local/gitconfig … identity と [include] path = ~/.gitconfig.local など"
+echo "     - local/gitconfig-personal / local/gitconfig.local / local/zshrc.local"
+echo "  2. シェルを開き直す（zinit・プラグインは初回起動時に自動インストール）"
+echo "  3. mise install / gh auth login などツール個別のログイン"
+echo ""
+echo -e "  以降の適用は ${BLUE}cd ${REPO_DIR} && make switch${RESET}"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -28,7 +28,10 @@ RESET='\033[0m'
 
 REPO_URL="https://github.com/yuucu/dotfiles"
 REPO_DIR="${HOME}/ghq/github.com/yuucu/dotfiles"
-FLAKE_TARGET="yuucu-mac"
+# username は実ログインユーザーに追従（flake.nix が DOTFILES_USER を参照）。
+DOTFILES_USER="$(whoami)"
+FLAKE_TARGET="${DOTFILES_USER}-mac"
+export DOTFILES_USER
 
 log() { echo -e "${BLUE}==> $*${RESET}"; }
 ok() { echo -e "  ${GREEN}✅ $*${RESET}"; }
@@ -108,14 +111,16 @@ fi
 # ----------------------------------------------------------------------------
 log "5/5 nix-darwin 初回適用（.#${FLAKE_TARGET}）"
 cd "${REPO_DIR}"
+# flake.nix は DOTFILES_USER を getEnv で参照するため --impure が必要。
+# sudo は環境変数を落とすので、DOTFILES_USER を明示的に引き渡す。
 if command -v darwin-rebuild >/dev/null 2>&1; then
-    ok "darwin-rebuild が既にある → make switch で適用"
-    sudo /run/current-system/sw/bin/darwin-rebuild switch --flake ".#${FLAKE_TARGET}"
+    ok "darwin-rebuild が既にある → switch で適用"
+    sudo DOTFILES_USER="${DOTFILES_USER}" /run/current-system/sw/bin/darwin-rebuild switch --impure --flake ".#${FLAKE_TARGET}"
 else
     warn "初回のため nix run で nix-darwin を適用します（sudo でパスワードを求められます）"
-    sudo nix run nix-darwin/master -- switch --flake ".#${FLAKE_TARGET}"
+    sudo DOTFILES_USER="${DOTFILES_USER}" nix run nix-darwin/master -- switch --impure --flake ".#${FLAKE_TARGET}"
 fi
-ok "適用完了"
+ok "適用完了（username: ${DOTFILES_USER}）"
 
 # ----------------------------------------------------------------------------
 # 完了 & 手作業の案内

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -23,7 +23,7 @@ if command -v nix >/dev/null 2>&1; then
         echo -e "  ❌ nix flake check failed"
         EXIT_CODE=1
     fi
-    if nix build ".#darwinConfigurations.${FLAKE_TARGET:-yuucu-mac}.system" --dry-run; then
+    if nix build ".#darwinConfigurations.${FLAKE_TARGET:-s09104-mac}.system" --dry-run; then
         echo -e "  ✅ nix build dry-run passed"
     else
         echo -e "  ❌ nix build dry-run failed"

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -23,7 +23,10 @@ if command -v nix >/dev/null 2>&1; then
         echo -e "  ❌ nix flake check failed"
         EXIT_CODE=1
     fi
-    if nix build ".#darwinConfigurations.${FLAKE_TARGET:-s09104-mac}.system" --dry-run; then
+    # nix build は pure eval のため attribute 名は flake の既定値に固定される。
+    # 名前を決め打ちせず flake 自身に問い合わせる（FLAKE_TARGET 指定時はそちらを優先）
+    FLAKE_TARGET="${FLAKE_TARGET:-$(nix eval .#darwinConfigurations --apply 'cfgs: builtins.head (builtins.attrNames cfgs)' --raw)}"
+    if nix build ".#darwinConfigurations.${FLAKE_TARGET}.system" --dry-run; then
         echo -e "  ✅ nix build dry-run passed"
     else
         echo -e "  ❌ nix build dry-run failed"


### PR DESCRIPTION
## 概要

Closes #43

mac への導入手順をワンライナー程度に減らすため、bootstrap スクリプトを新設した。

```bash
curl -fsSL https://raw.githubusercontent.com/yuucu/dotfiles/main/scripts/bootstrap.sh | bash
```

## 変更内容

- `scripts/bootstrap.sh`（新規）
  - Xcode CLT / Homebrew / Nix / clone / 初回 `darwin-rebuild switch` を非対話・冪等に実行
  - 各ステップは既インストールならスキップ（何度実行しても壊れない）
  - 完了後に残りの手作業（`local/` 作成・シェル再起動・`mise install`/`gh auth login`）を案内
  - 既存 `scripts/ci-check.sh` の作法（`set -euo pipefail`・色付き出力）に合わせた
- `README.md`
  - セットアップ冒頭にワンライナー導線を追加
  - 既存の 6 ステップは「手動セットアップ」として温存

## 留意点

- `flake.nix` の `username` と `FLAKE_TARGET` はハードコードのまま。別ユーザー名のマシンでそのまま通すには username 動的化が別途必要（本 PR のスコープ外）
- ワンライナーには対話（Xcode CLT ダイアログ・sudo パスワード）が原理的に残る

## 検証

- `nix flake check`（shellcheck 含む lint 群）✅
- `bash -n scripts/bootstrap.sh`（構文）✅
- pre-commit（gitleaks / lint-staged）・pre-push（flake-check）✅
- 実機での通し実行は未確認（新規 Mac が必要なため）