### PR TITLE
feat(nvim): proto の treesitter シンタックスハイライト対応

### DIFF
--- a/config/nvim/lua/plugins/treesitter.lua
+++ b/config/nvim/lua/plugins/treesitter.lua
@@ -19,6 +19,7 @@ local parsers = {
   'json5',
   'terraform',
   'hcl',
+  'proto',
   'bash',
   'c',
   'html',


### PR DESCRIPTION
## 概要

treesitter の parser リストに `proto` を追加し、`.proto` ファイルのシンタックスハイライトに対応した。

## 変更内容

- `config/nvim/lua/plugins/treesitter.lua` の parsers に `proto` を追加

## 備考

- `.proto` の FileType 判定は Neovim 本体が標準で行うため、既存の FileType autocmd でハイライトが起動する
- #46 の sql 対応と同じパターン